### PR TITLE
V2 lastobs write eits

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1172,7 +1172,7 @@ def main_v03(argv):
             debuglevel,
             run_results,
             data_assimilation_parameters,
-            link_gage_df['gages'],
+            link_gage_df,
         )
 
     # nwm_final_output_generator()
@@ -1387,7 +1387,7 @@ async def main_v03_async(argv):
             debuglevel,
             run_results,
             data_assimilation_parameters,
-            link_gage_df['gages'],
+            link_gage_df,
         )
 
     # For the last loop, no next forcing or warm state is needed for execution.
@@ -1467,7 +1467,7 @@ async def main_v03_async(argv):
         debuglevel,
         run_results,
         data_assimilation_parameters,
-        link_gage_df['gages'],
+        link_gage_df,
     )
 
     if verbose:

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -203,9 +203,9 @@ def nwm_output_generator(
             # usgs_df_filtered = usgs_df[usgs_df.index.isin(csv_output_segments)]
             # usgs_df_filtered.to_csv(output_path.joinpath("usgs_df.csv"))
             
-        # build new lastobs_df and write out LastObs as netcdf. 
-        # Assumed that this capability is only needed for AnA simulations
-        # i.e. when timeslice files are provided to support DA
+    # build new lastobs_df and write out LastObs as netcdf. 
+    # Assumed that this capability is only needed for AnA simulations
+    # i.e. when timeslice files are provided to support DA
     data_assimilation_folder = data_assimilation_parameters.get(
     "data_assimilation_timeslices_folder", None
     )

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -21,7 +21,7 @@ def nwm_output_generator(
     debuglevel=0,
     run_results=False,
     data_assimilation_parameters=False,
-    gages=False,
+    link_gage_df=None,
 ):
     dt = run.get("dt")
     nts = run.get("nts")
@@ -209,14 +209,14 @@ def nwm_output_generator(
     data_assimilation_folder = data_assimilation_parameters.get(
     "data_assimilation_timeslices_folder", None
     )
-
+    
     if data_assimilation_folder:
         lastobs_df = nhd_io.lastobs_df_output(
             dt,
             nts,
             t0,
             run_results,
-            gages,
+            link_gage_df['gages'],
             data_assimilation_parameters.get('lastobs_output_folder',False),
         ) 
 

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -331,7 +331,7 @@ def nwm_forcing_preprocess(
             start_time = time.time()
         if verbose:
             print("creating usgs time_slice data array ...")
-        usgs_df = nnu.build_data_assimilation_usgs_df(da_run, run, lastobs_index)
+        usgs_df, link_gage_df = nnu.build_data_assimilation_usgs_df(da_run, run, lastobs_index)
 
         if verbose:
             print("usgs array complete")
@@ -340,6 +340,7 @@ def nwm_forcing_preprocess(
 
     else:
         usgs_df = pd.DataFrame()
+        link_gage_df = pd.DataFrame()
 
     # STEP 7
     coastal_boundary_elev = forcing_parameters.get("coastal_boundary_elev_data", None)
@@ -354,4 +355,4 @@ def nwm_forcing_preprocess(
         coastal_ncdf_df = nhd_io.build_coastal_ncdf_dataframe(coastal_ncdf)
 
     # TODO: disentangle the implicit (run) and explicit (qlats_df, usgs_df) returns
-    return qlats_df, usgs_df
+    return qlats_df, usgs_df, link_gage_df

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -660,9 +660,10 @@ def get_usgs_df_from_csv(usgs_csv, routelink_subset_file, index_col="link"):
         df = ds.to_dataframe()
 
     usgs_df = df.join(df2)
+    link_gage_df = usgs_df[['gages']]
     usgs_df = usgs_df.drop(["gages", "ascendingIndex", "to"], axis=1)
 
-    return usgs_df
+    return usgs_df, link_gage_df
 
 
 def get_usgs_from_time_slices_folder(
@@ -717,12 +718,16 @@ def get_usgs_from_time_slices_folder(
             data_var_dict[v] = (["gages"], ds[v].values[gage_mask])
         ds = xr.Dataset(data_vars=data_var_dict, coords={"gages": gage_da})
     df = ds.to_dataframe()
-
+    
     usgs_df = (df.join(df2).
                reset_index().
                rename(columns={"index": "gages"}).
-               set_index("link").
-               drop(["gages", "ascendingIndex", "to"], axis=1))
+               set_index("link"))
+    
+    # data frame containing link-gage crosswalk
+    link_gage_df = usgs_df[['gages']]
+    
+    usgs_df = usgs_df.drop(["gages", "ascendingIndex", "to"], axis=1)
 
     usgs_qual_df = (df.join(df_qual).
                reset_index().
@@ -812,7 +817,7 @@ def get_usgs_from_time_slices_folder(
     # usgs_df_T.reindex(dates)
     usgs_df_new = usgs_df_T.transpose()
 
-    return usgs_df_new
+    return usgs_df_new, link_gage_df
 
 
 def get_param_str(target_file, param):


### PR DESCRIPTION
- fixed implementation of lastobs write capability in v2 execution pathway
- rather than getting gage ID information from the lastobs_df read in at the beginning of a simulation, I am getting gage ID information from the usgs_df and passing it throughout the execution pathways in a new variable called `link_gage_df`. The reason for doing this is that the lastobs_df may not exist in a cold-started DA simulation (i.e. TimeSlice files, but no lastobs_df). In this situation, we would still need to write lastobs but, the workflow would fail because there is no gages variable in the lastobs_df. 
